### PR TITLE
channel select operation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,13 +3,9 @@
 #     - luncliff@gmail.com
 #   Reference
 #     - https://www.appveyor.com/docs/appveyor-yml/
+#     - https://github.com/appveyor/ci/issues/899#issuecomment-230360978
 #
 version: 1.4.{build}
-
-clone_script:
-  # https://github.com/appveyor/ci/issues/899#issuecomment-230360978
-  - ps: git clone -q --recursive --branch $env:APPVEYOR_REPO_BRANCH https://github.com/$env:APPVEYOR_REPO_NAME.git $env:APPVEYOR_BUILD_FOLDER
-  - ps: git checkout -qf $env:APPVEYOR_REPO_COMMIT
 
 notifications:
   - provider: Email

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,9 @@
 #
 version: 1.4.{build}
 
+clone_script:  
+  - ps: git clone -q --recursive --branch $env:APPVEYOR_REPO_BRANCH https://github.com/$env:APPVEYOR_REPO_NAME.git $env:APPVEYOR_BUILD_FOLDER
+
 notifications:
   - provider: Email
     to:

--- a/interface/coroutine/channel.hpp
+++ b/interface/coroutine/channel.hpp
@@ -355,7 +355,7 @@ class channel final : internal::list<reader<T, M>>, internal::list<writer<T, M>>
 
 // Extension of channel reader for subroutines
 template <typename T, typename M>
-class peeker final : public reader<T, M>
+class peeker final : protected reader<T, M>
 {
     using value_type = T;
     using channel_type = channel<T, M>;

--- a/interface/coroutine/channel.hpp
+++ b/interface/coroutine/channel.hpp
@@ -10,7 +10,6 @@
 #ifndef COROUTINE_CHANNEL_HPP
 #define COROUTINE_CHANNEL_HPP
 
-#include <cassert>
 #include <mutex>
 #include <tuple>
 
@@ -18,6 +17,7 @@
 
 namespace coro
 {
+using namespace std;
 using namespace std::experimental;
 
 namespace internal
@@ -27,15 +27,14 @@ static void* poison() noexcept(false)
     return reinterpret_cast<void*>(0xFADE'038C'BCFA'9E64);
 }
 
-// - Note
-//      Minimal linked list without node allocation
-template <typename NodeType>
+// Linked list without allocation
+template <typename T>
 class list
 {
-    using node_t = NodeType;
+    using node_type = T;
 
-    node_t* head{};
-    node_t* tail{};
+    node_type* head{};
+    node_type* tail{};
 
   public:
     list() noexcept = default;
@@ -45,7 +44,7 @@ class list
     {
         return head == nullptr;
     }
-    void push(node_t* node) noexcept(false)
+    void push(node_type* node) noexcept(false)
     {
         if (tail)
         {
@@ -55,9 +54,9 @@ class list
         else
             head = tail = node;
     }
-    auto pop() noexcept(false) -> node_t*
+    auto pop() noexcept(false) -> node_type*
     {
-        node_t* node = head;
+        node_type* node = head;
         if (head == tail) // empty or 1
             head = tail = nullptr;
         else // 2 or more
@@ -68,23 +67,24 @@ class list
 };
 } // namespace internal
 
-template <typename T, typename Lockable>
+template <typename T, typename M>
 class channel;
-template <typename T, typename Lockable>
+template <typename T, typename M>
 class reader;
-template <typename T, typename Lockable>
+template <typename T, typename M>
 class writer;
+template <typename T, typename M>
+class peeker;
 
-// - Note
-//      Awaitable reader for `channel`
-template <typename T, typename Lockable>
-class reader final
+// Awaitable Type for channel's read operation
+template <typename T, typename M>
+class reader
 {
   public:
     using value_type = T;
     using pointer = T*;
     using reference = T&;
-    using channel_type = channel<T, Lockable>;
+    using channel_type = channel<T, M>;
 
   private:
     using writer = typename channel_type::writer;
@@ -93,9 +93,10 @@ class reader final
 
     friend channel_type;
     friend writer;
+    friend peeker;
     friend reader_list;
 
-  private:
+  protected:
     mutable pointer ptr; // Address of value
     mutable void* frame; // Resumeable Handle
     union {
@@ -105,7 +106,7 @@ class reader final
 
   private:
     explicit reader(channel_type& ch) noexcept(false)
-        : ptr{}, frame{nullptr}, chan{std::addressof(ch)}
+        : ptr{}, frame{nullptr}, chan{addressof(ch)}
     {
     }
     reader(const reader&) noexcept(false) = delete;
@@ -114,35 +115,73 @@ class reader final
   public:
     reader(reader&& rhs) noexcept(false)
     {
-        std::swap(this->ptr, rhs.ptr);
-        std::swap(this->frame, rhs.frame);
-        std::swap(this->chan, rhs.chan);
+        swap(this->ptr, rhs.ptr);
+        swap(this->frame, rhs.frame);
+        swap(this->chan, rhs.chan);
     }
     reader& operator=(reader&& rhs) noexcept(false)
     {
-        std::swap(this->ptr, rhs.ptr);
-        std::swap(this->frame, rhs.frame);
-        std::swap(this->chan, rhs.chan);
+        swap(this->ptr, rhs.ptr);
+        swap(this->frame, rhs.frame);
+        swap(this->chan, rhs.chan);
         return *this;
     }
     ~reader() noexcept = default;
 
   public:
-    bool await_ready() const noexcept(false);
-    void await_suspend(coroutine_handle<void> rh) noexcept(false);
-    auto await_resume() noexcept(false) -> std::tuple<value_type, bool>;
+    bool await_ready() const noexcept(false)
+    {
+        chan->mtx.lock();
+        if (chan->writer_list::is_empty())
+            return false;
+
+        writer* w = chan->writer_list::pop();
+        // exchange address & resumeable_handle
+        swap(this->ptr, w->ptr);
+        swap(this->frame, w->frame);
+
+        chan->mtx.unlock();
+        return true;
+    }
+    void await_suspend(coroutine_handle<void> coro) noexcept(false)
+    {
+        // notice that next & chan are sharing memory
+        channel_type& ch = *(this->chan);
+
+        this->frame = coro.address(); // remember handle before push/unlock
+        this->next = nullptr;         // clear to prevent confusing
+
+        ch.reader_list::push(this); // push to channel
+        ch.mtx.unlock();
+    }
+    auto await_resume() noexcept(false) -> tuple<value_type, bool>
+    {
+        auto t = make_tuple(value_type{}, false);
+        // frame holds poision if the channel is going to be destroyed
+        if (this->frame == internal::poison())
+            return t;
+
+        // Store first. we have to do this because the resume operation
+        // can destroy the writer coroutine
+        auto& value = get<0>(t);
+        value = move(*ptr);
+        if (auto coro = coroutine_handle<void>::from_address(frame))
+            coro.resume();
+
+        get<1>(t) = true;
+        return t;
+    }
 };
 
-// - Note
-//      Awaitable writer for `channel`
-template <typename T, typename Lockable>
+// Awaitable Type for channel's write operation
+template <typename T, typename M>
 class writer final
 {
   public:
     using value_type = T;
     using pointer = T*;
     using reference = T&;
-    using channel_type = channel<T, Lockable>;
+    using channel_type = channel<T, M>;
 
   private:
     using reader = typename channel_type::reader;
@@ -151,6 +190,7 @@ class writer final
 
     friend channel_type;
     friend reader;
+    friend peeker;
     friend writer_list;
 
   private:
@@ -163,7 +203,7 @@ class writer final
 
   private:
     explicit writer(channel_type& ch, pointer pv) noexcept(false)
-        : ptr{pv}, frame{nullptr}, chan{std::addressof(ch)}
+        : ptr{pv}, frame{nullptr}, chan{addressof(ch)}
     {
     }
     writer(const writer&) noexcept(false) = delete;
@@ -172,221 +212,206 @@ class writer final
   public:
     writer(writer&& rhs) noexcept(false)
     {
-        std::swap(this->ptr, rhs.ptr);
-        std::swap(this->frame, rhs.frame);
-        std::swap(this->chan, rhs.chan);
+        swap(this->ptr, rhs.ptr);
+        swap(this->frame, rhs.frame);
+        swap(this->chan, rhs.chan);
     }
     writer& operator=(writer&& rhs) noexcept(false)
     {
-        std::swap(this->ptr, rhs.ptr);
-        std::swap(this->frame, rhs.frame);
-        std::swap(this->chan, rhs.chan);
+        swap(this->ptr, rhs.ptr);
+        swap(this->frame, rhs.frame);
+        swap(this->chan, rhs.chan);
         return *this;
     }
     ~writer() noexcept = default;
 
   public:
-    bool await_ready() const noexcept(false);
-    void await_suspend(coroutine_handle<void> _rh) noexcept(false);
-    bool await_resume() noexcept(false);
+    bool await_ready() const noexcept(false)
+    {
+        chan->mtx.lock();
+        if (chan->reader_list::is_empty())
+            return false;
+
+        reader* r = chan->reader_list::pop();
+        // exchange address & resumeable_handle
+        swap(this->ptr, r->ptr);
+        swap(this->frame, r->frame);
+
+        chan->mtx.unlock();
+        return true;
+    }
+    void await_suspend(coroutine_handle<void> coro) noexcept(false)
+    {
+        // notice that next & chan are sharing memory
+        channel_type& ch = *(this->chan);
+
+        this->frame = coro.address(); // remember handle before push/unlock
+        this->next = nullptr;         // clear to prevent confusing
+
+        ch.writer_list::push(this); // push to channel
+        ch.mtx.unlock();
+    }
+    bool await_resume() noexcept(false)
+    {
+        // frame holds poision if the channel is going to destroy
+        if (this->frame == internal::poison())
+            return false;
+
+        if (auto coro = coroutine_handle<void>::from_address(frame))
+            coro.resume();
+
+        return true;
+    }
 };
 
-// - Note
-//      Coroutine Channel
-//      Channel doesn't support Copy, Move
-template <typename T, typename Lockable>
-class channel final : internal::list<reader<T, Lockable>>,
-                      internal::list<writer<T, Lockable>>
+// Coroutine based channel. User have to provide mutex(lockable) type
+template <typename T, typename M>
+class channel final : internal::list<reader<T, M>>, internal::list<writer<T, M>>
 {
-    static_assert(std::is_reference<T>::value == false,
-                  "Using reference for channel is forbidden.");
+    static_assert(is_reference<T>::value == false,
+                  "reference type can'y be channel's value_type.");
 
   public:
     using value_type = T;
     using pointer = value_type*;
     using reference = value_type&;
 
-    using mutex_t = Lockable;
+    using mutex_type = M;
 
   private:
-    using reader = reader<value_type, mutex_t>;
+    using reader = reader<value_type, mutex_type>;
     using reader_list = internal::list<reader>;
 
-    using writer = writer<value_type, mutex_t>;
+    using writer = writer<value_type, mutex_type>;
     using writer_list = internal::list<writer>;
 
     friend reader;
     friend writer;
+    friend peeker;
 
   private:
-    mutex_t mtx{};
+    mutex_type mtx{};
 
   public:
+    channel(const channel&) noexcept(false) = delete;
+    channel(channel&&) noexcept(false) = delete;
+    channel& operator=(const channel&) noexcept(false) = delete;
+    channel& operator=(channel&&) noexcept(false) = delete;
     channel() noexcept(false) : reader_list{}, writer_list{}, mtx{}
     {
     }
-    channel(const channel&) noexcept(false) = delete;
-    channel(channel&&) noexcept(false) = delete;
-
-    channel& operator=(const channel&) noexcept(false) = delete;
-    channel& operator=(channel&&) noexcept(false) = delete;
-
-    ~channel() noexcept(false)
+    ~channel() noexcept(false) // channel can't provide exception guarantee...
     {
         writer_list& writers = *this;
         reader_list& readers = *this;
-
         //
-        // Because of thread scheduling,
-        // Some coroutines can be enqueued into list just after
-        // this destructor unlocks.
+        // If the channel is raced hardly, some coroutines can be
+        //  enqueued into list just after this destructor unlocks mutex.
         //
-        // But this can't be detected at once since
-        // we have 2 list in the channel...
+        // Unfortunately, this can't be detected at once since
+        //  we have 2 list (readers/writers) in the channel.
         //
-        // Current implementation triggers scheduling repeatedly
-        // to reduce the possibility. As repeat count becomes greater,
-        // the possibility drops to zero. But notice that it is NOT zero.
+        // Current implementation allows checking repeatedly to reduce the
+        //  probability of such interleaving.
+        // Increase the repeat count below if the situation occurs.
+        // But notice that it is NOT zero.
         //
-        size_t repeat = 1; // recommend 5'000+ repeat for hazard usage
+        size_t repeat = 1; // author experienced 5'000+ for hazard usage
         do
         {
-            std::unique_lock lck{this->mtx};
+            unique_lock lck{mtx};
 
             while (writers.is_empty() == false)
             {
                 writer* w = writers.pop();
-                auto rh = coroutine_handle<void>::from_address(w->frame);
+                auto coro = coroutine_handle<void>::from_address(w->frame);
                 w->frame = internal::poison();
 
-                rh.resume();
+                coro.resume();
             }
             while (readers.is_empty() == false)
             {
                 reader* r = readers.pop();
-                auto rh = coroutine_handle<void>::from_address(r->frame);
+                auto coro = coroutine_handle<void>::from_address(r->frame);
                 r->frame = internal::poison();
 
-                rh.resume();
+                coro.resume();
             }
         } while (repeat--);
     }
 
   public:
-    // - Note
-    //      Awaitable write.
-    //      `writer` type implements the awaitable concept
     decltype(auto) write(reference ref) noexcept(false)
     {
-        return writer{*this, std::addressof(ref)};
+        return writer{*this, addressof(ref)};
     }
-    // - Note
-    //      Awaitable read.
-    //      `reader` type implements the awaitable concept
     decltype(auto) read() noexcept(false)
     {
         return reader{*this};
     }
 };
 
+// Extension of channel reader for subroutines
 template <typename T, typename M>
-bool reader<T, M>::await_ready() const noexcept(false)
+class peeker final : protected reader<T, M>
 {
-    chan->mtx.lock();
-    if (chan->writer_list::is_empty())
-        return false;
-
-    writer* w = chan->writer_list::pop();
-    assert(w != nullptr);
-    assert(w->ptr != nullptr);
-    assert(w->frame != nullptr);
-
-    // exchange address & resumeable_handle
-    std::swap(this->ptr, w->ptr);
-    std::swap(this->frame, w->frame);
-
-    chan->mtx.unlock();
-    return true;
-}
-
-template <typename T, typename M>
-void reader<T, M>::await_suspend(coroutine_handle<void> coro) noexcept(false)
-{
-    // notice that next & chan are sharing memory
-    channel_type& ch = *(this->chan);
-
-    this->frame = coro.address(); // remember handle before push/unlock
-    this->next = nullptr;         // clear to prevent confusing
-
-    ch.reader_list::push(this); // push to channel
-    ch.mtx.unlock();
-}
-
-template <typename T, typename M>
-auto reader<T, M>::await_resume() noexcept(false)
-    -> std::tuple<value_type, bool>
-{
-    // frame holds poision if the channel is going to destroy
-    if (this->frame == internal::poison())
-        return std::make_tuple(value_type{}, false);
-
-    // Store first. we have to do this
-    // because the resume operation can destroy the writer coroutine
-    value_type value = std::move(*ptr);
-    if (auto rh = coroutine_handle<void>::from_address(frame))
+  public:
+    explicit peeker(channel_type& ch) noexcept(false) : reader{ch}
     {
-        assert(this->frame != nullptr);
-        assert(*reinterpret_cast<uint64_t*>(frame) != 0);
-        rh.resume();
     }
+    peeker(const peeker&) noexcept(false) = delete;
+    peeker(peeker&& rhs) noexcept(false) = delete;
+    peeker& operator=(const peeker&) noexcept(false) = delete;
+    peeker& operator=(peeker&& rhs) noexcept(false) = delete;
+    ~peeker() noexcept = default;
 
-    return std::make_tuple(std::move(value), true);
-}
-
-template <typename T, typename M>
-bool writer<T, M>::await_ready() const noexcept(false)
-{
-    chan->mtx.lock();
-    if (chan->reader_list::is_empty())
-        return false;
-
-    reader* r = chan->reader_list::pop();
-    // exchange address & resumeable_handle
-    std::swap(this->ptr, r->ptr);
-    std::swap(this->frame, r->frame);
-
-    chan->mtx.unlock();
-    return true;
-}
-
-template <typename T, typename M>
-void writer<T, M>::await_suspend(coroutine_handle<void> coro) noexcept(false)
-{
-    // notice that next & chan are sharing memory
-    channel_type& ch = *(this->chan);
-
-    this->frame = coro.address(); // remember handle before push/unlock
-    this->next = nullptr;         // clear to prevent confusing
-
-    ch.writer_list::push(this); // push to channel
-    ch.mtx.unlock();
-}
-
-template <typename T, typename M>
-bool writer<T, M>::await_resume() noexcept(false)
-{
-    // frame holds poision if the channel is going to destroy
-    if (this->frame == internal::poison())
-        return false;
-
-    if (auto rh = coroutine_handle<void>::from_address(frame))
+  public:
+    void peek() const noexcept(false)
     {
-        assert(this->frame != nullptr);
-        assert(*reinterpret_cast<uint64_t*>(frame) != 0);
-        rh.resume();
+        // since there is no suspension, use scoped locking
+        unique_lock lck{chan->mtx};
+        if (chan->writer_list::is_empty() == false)
+        {
+            writer* w = chan->writer_list::pop();
+            swap(this->ptr, w->ptr);
+            swap(this->frame, w->frame);
+        }
     }
-    return true;
+    bool acquire(reference storage) noexcept(false)
+    {
+        // if there was a writer, take its value
+        if (ptr == nullptr)
+            return false;
+        storage = move(*ptr);
+
+        // resume writer coroutine
+        if (auto coro = coroutine_handle<void>::from_address(frame))
+            coro.resume();
+        return true;
+    }
+};
+
+// If the channel is readable, acquire the value and the function.
+template <typename T, typename M, typename Fn>
+void select(channel<T, M>& ch, Fn&& fn) noexcept(false)
+{
+    static_assert(sizeof(reader<T, M>) == sizeof(peeker<T, M>));
+
+    peeker<T, M> p{ch};
+    T storage{}; // peeker will move element into the call stack
+
+    if (p.peek(), p.acquire(storage)) // if acquired,
+        fn(storage);                  //   invoke the function
 }
+
+// Invoke `select` for pairs (channel + function)
+template <typename... Args, typename ChanType, typename FuncType>
+void select(ChanType& ch, FuncType&& fn, Args&&... args) noexcept(false)
+{
+    select(ch, forward<FuncType&&>(fn));     // evaluate
+    return select(forward<Args&&>(args)...); // try next pair
+}
+
 } // namespace coro
 
 #endif // COROUTINE_CHANNEL_HPP

--- a/interface/coroutine/suspend.h
+++ b/interface/coroutine/suspend.h
@@ -90,7 +90,7 @@ _INTERFACE_ auto make_lock_queue() -> std::unique_ptr<limited_lock_queue>;
 //      Return an awaitable that enqueue the coroutine
 //      Relay code will be generated with this header to minimize dllexport
 //      functions
-static auto push_to(limited_lock_queue& queue) noexcept
+inline auto push_to(limited_lock_queue& queue) noexcept
 {
     // awaitable for the queue
     class redirect_to final : public suspend_always
@@ -111,7 +111,7 @@ static auto push_to(limited_lock_queue& queue) noexcept
     return redirect_to{queue};
 }
 
-static auto pop_from(limited_lock_queue& queue) noexcept
+inline auto pop_from(limited_lock_queue& queue) noexcept
     -> coroutine_handle<void>
 {
     void* ptr = nullptr;
@@ -119,6 +119,6 @@ static auto pop_from(limited_lock_queue& queue) noexcept
     return coroutine_handle<void>::from_address(ptr);
 }
 
-} // namespace co_ex
+} // namespace coro
 
 #endif // COROUTINE_SUSPEND_HELPER_TYPES_H

--- a/test/channel/channel_test.h
+++ b/test/channel/channel_test.h
@@ -42,7 +42,7 @@ auto write_to(channel<E, L>& ch, E value, bool ok = false) -> return_ignore
     ok = co_await ch.write(value);
     if (ok == false)
         // !!!!!
-        // seems like optimizer is removing `value`.
+        // seems like clang optimizer is removing `value`.
         // so using it in some pass makes
         // the symbol and its memory location alive
         // !!!!!


### PR DESCRIPTION
## Note

`select` and `peek` operation for the `channel` type.

### Concerns

* `select` is a well known function for socket(`FD_SET`) operation.

### Example

```c++
TEST_CASE("channel select", "[generic][channel]")
{
    // it's singe thread, so mutex for channels doesn't have to be real lockable
    using u32_chan_t = channel<uint32_t, bypass_lock>;
    using i32_chan_t = channel<int32_t, bypass_lock>;

    SECTION("match one")
    {
        u32_chan_t ch1{};
        i32_chan_t ch2{};

        write_to(ch1, 17u);
        select(ch2,
               [](auto v) {
                   static_assert(is_same_v<decltype(v), int32_t>);
                   FAIL("select on empty channel must bypass");
               },
               ch1,
               [](auto v) -> return_ignore {
                   static_assert(is_same_v<decltype(v), uint32_t>);
                   REQUIRE(v == 17u);
                   co_await suspend_never{};
               });
    }

    SECTION("no match")
    {
        u32_chan_t ch1{};
        i32_chan_t ch2{};

        select(ch1,
               [](auto v) {
                   static_assert(is_same_v<decltype(v), uint32_t>);
                   FAIL("select on empty channel must bypass");
               },
               ch2,
               [](auto v) {
                   static_assert(is_same_v<decltype(v), int32_t>);
                   FAIL("select on empty channel must bypass");
               });
    }

    SECTION("match both")
    {
        u32_chan_t ch1{};
        i32_chan_t ch2{};

        write_to(ch1, 17u);
        write_to(ch2, 15);

        select(ch2, [](auto v) { REQUIRE(v == 15); }, //
               ch1, [](auto v) { REQUIRE(v == 17u); } //
        );
    }
};
```