### PR TITLE
awaitable event type

### DIFF
--- a/.azure/create-coverage-xml.ps1
+++ b/.azure/create-coverage-xml.ps1
@@ -3,7 +3,7 @@ $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Te
 
 # Acquire coverage file and generate temporary coverage file
 $coverage_file = Get-ChildItem -Recurse *.coverage;
-Write-Host $coverage_file
+Write-Output $coverage_file
 $temp_coverage_xml_filepath  = "./TestResults/coverage-report.xml"
 CodeCoverage.exe analyze /output:$temp_coverage_xml_filepath $coverage_file
 
@@ -15,6 +15,7 @@ $final_coverage_xml_filepath = "./TestResults/luncliff-coroutine-visual-studio.c
 $xml_lines = Get-Content $temp_coverage_xml_filepath
 foreach($text in $xml_lines){
     if($text -match 15732480){
+        Write-Output "removed $text"
         continue;
     }
     else {

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ script:
     -DCMAKE_BUILD_TYPE=${CONFIG}
     -DCMAKE_INSTALL_PREFIX=../install
     -DCMAKE_CXX_COMPILER=${CXX}
+    ${EXT_ARGS}
   - ninja install;
   - ./test/coroutine_test;
   - cd -;
@@ -155,3 +156,35 @@ matrix:
         - gradle assemble -warning-mode all
       after_success:
         - tree ./install
+
+    #
+    # test implementation in <coroutine/frame.h>
+    #
+
+    - name: Mac Debug (Custom)
+      os: osx
+      osx_image: xcode10.2
+      env:
+        - CONFIG=Debug    SHARED=true
+        - EXT_ARGS=-DUSE_CUSTOM_HEADER
+
+    - name: Mac Release (Custom)
+      os: osx
+      osx_image: xcode10.2
+      env:
+        - CONFIG=Release  SHARED=true
+        - EXT_ARGS=-DUSE_CUSTOM_HEADER
+
+    - name: Ubuntu(Xenial) Debug (Custom)
+      os: linux
+      dist: xenial
+      env:
+        - CONFIG=Debug    SHARED=true
+        - EXT_ARGS=-DUSE_CUSTOM_HEADER
+
+    - name: Ubuntu(Xenial) Release (Custom)
+      os: linux
+      dist: xenial
+      env:
+        - CONFIG=Release  SHARED=true
+        - EXT_ARGS=-DUSE_CUSTOM_HEADER

--- a/.travis.yml
+++ b/.travis.yml
@@ -166,25 +166,25 @@ matrix:
       osx_image: xcode10.2
       env:
         - CONFIG=Debug    SHARED=true
-        - EXT_ARGS=-DUSE_CUSTOM_HEADER
+        - EXT_ARGS=-DUSE_CUSTOM_HEADER=true
 
     - name: Mac Release (Custom)
       os: osx
       osx_image: xcode10.2
       env:
         - CONFIG=Release  SHARED=true
-        - EXT_ARGS=-DUSE_CUSTOM_HEADER
+        - EXT_ARGS=-DUSE_CUSTOM_HEADER=true
 
     - name: Ubuntu(Xenial) Debug (Custom)
       os: linux
       dist: xenial
       env:
         - CONFIG=Debug    SHARED=true
-        - EXT_ARGS=-DUSE_CUSTOM_HEADER
+        - EXT_ARGS=-DUSE_CUSTOM_HEADER=true
 
     - name: Ubuntu(Xenial) Release (Custom)
       os: linux
       dist: xenial
       env:
         - CONFIG=Release  SHARED=true
-        - EXT_ARGS=-DUSE_CUSTOM_HEADER
+        - EXT_ARGS=-DUSE_CUSTOM_HEADER=true

--- a/interface/coroutine/concrt.h
+++ b/interface/coroutine/concrt.h
@@ -197,7 +197,7 @@ class latch final : no_copy_move {
 //  If it is signaled before `co_await`, it will return `true` for `await_ready`
 //  so the coroutine can bypass suspension steps.
 //  The event object can be `co_await`ed multiple times.
-class event : no_copy_move {
+class event final : no_copy_move {
   public:
     using task = coroutine_handle<void>;
 

--- a/interface/coroutine/concrt.h
+++ b/interface/coroutine/concrt.h
@@ -194,11 +194,13 @@ class event : no_copy_move {
     using task = coroutine_handle<void>;
 
   private:
-    uint64_t id; // internal identifier
-    void* internal;
+    uint64_t id;
+    task coro;
 
   private:
     _INTERFACE_ void on_suspend(task) noexcept(false);
+    _INTERFACE_ bool is_ready() noexcept;
+    _INTERFACE_ void on_resume() noexcept;
 
   public:
     _INTERFACE_ event() noexcept(false);
@@ -206,13 +208,14 @@ class event : no_copy_move {
 
     _INTERFACE_ void set() noexcept(false);
 
-    constexpr bool await_ready() noexcept {
-        return false;
+    bool await_ready() noexcept {
+        return this->is_ready();
     }
     void await_suspend(coroutine_handle<void> coro) noexcept(false) {
         return this->on_suspend(coro);
     }
-    constexpr void await_resume() noexcept {
+    void await_resume() noexcept {
+        return this->on_resume();
     }
 };
 _INTERFACE_

--- a/interface/coroutine/concrt.h
+++ b/interface/coroutine/concrt.h
@@ -5,7 +5,7 @@
 //
 //  References
 //      https://en.cppreference.com/w/cpp/experimental/concurrency
-//		https://en.cppreference.com/w/cpp/experimental/latch
+//      https://en.cppreference.com/w/cpp/experimental/latch
 //      https://github.com/alasdairmackintosh/google-concurrency-library
 //      https://docs.microsoft.com/en-us/windows/desktop/ProcThread/using-the-thread-pool-functions
 //
@@ -41,7 +41,8 @@
 #include <coroutine/return.h>
 #include <coroutine/yield.hpp>
 
-// disable copy/move operation of the type
+namespace concrt {
+//  Disable copy/move operation of the child types
 struct no_copy_move {
     no_copy_move() noexcept = default;
     ~no_copy_move() noexcept = default;
@@ -50,6 +51,7 @@ struct no_copy_move {
     no_copy_move& operator=(no_copy_move&) = delete;
     no_copy_move& operator=(no_copy_move&&) = delete;
 };
+} // namespace concrt
 
 #if __has_include(<Windows.h>) // ... activate VC++ based features ...
 
@@ -66,7 +68,7 @@ namespace concrt {
 using namespace std;
 using namespace std::experimental;
 
-// enumerate current existing thread id of with the process id
+//  Enumerate current existing thread id of with the process id
 _INTERFACE_
 auto get_threads(DWORD owner_pid) noexcept(false) -> coro::enumerable<DWORD>;
 
@@ -129,8 +131,8 @@ class ptp_event final : no_copy_move {
     }
 };
 
-//	An `std::experimental::latch` for fork-join scenario.
-//	Its interface might slightly with that of Concurrency TS
+//  An `std::experimental::latch` for fork-join scenario.
+//  Its interface might slightly with that of Concurrency TS
 class latch final : no_copy_move {
     mutable HANDLE ev{};
     atomic_uint64_t ref{};
@@ -169,8 +171,8 @@ class section final : no_copy_move {
     _INTERFACE_ void unlock() noexcept(false);
 };
 
-//	An `std::experimental::latch` for fork-join scenario.
-//	Its interface might slightly with that of Concurrency TS
+//  An `std::experimental::latch` for fork-join scenario.
+//  Its interface might slightly with that of Concurrency TS
 class latch final : no_copy_move {
     atomic_uint64_t ref{};
     pthread_cond_t cv{};
@@ -189,7 +191,7 @@ class latch final : no_copy_move {
     _INTERFACE_ void wait() noexcept(false);
 };
 
-//	Awaitable event type.
+//  Awaitable event type.
 //  If the event object is signaled(`set`), the library will yield suspended
 //  coroutine via `signaled_event_tasks` function.
 //  If it is signaled before `co_await`, it will return `true` for `await_ready`
@@ -224,11 +226,11 @@ class event : no_copy_move {
     }
 };
 
-//  yield all suspended coroutines that are waiting for signaled events.
+//  Enumerate all suspended coroutines that are waiting for signaled events.
 _INTERFACE_
 auto signaled_event_tasks() noexcept(false) -> coro::enumerable<event::task>;
 
 } // namespace concrt
-#endif // system API dependent features
 
+#endif // system API dependent features
 #endif // COROUTINE_CONCURRENCY_HELPERS_H

--- a/interface/coroutine/concrt.h
+++ b/interface/coroutine/concrt.h
@@ -53,6 +53,9 @@ struct no_copy_move {
 #if __has_include(<Windows.h>) // ... activate VC++ based features ...
 
 // clang-format off
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <Windows.h>
 #include <threadpoolapiset.h>
 #include <synchapi.h>

--- a/interface/coroutine/frame.h
+++ b/interface/coroutine/frame.h
@@ -24,29 +24,33 @@
 //	VC++ won't fit clang-cl's code generation. see the implementation below
 //
 #if defined(_EXPERIMENTAL_RESUMABLE_)
-#error                                                                         \
-    "This header replaces <experimental/coroutine> for clang-cl and VC++ header";
+#error "This header replaces <experimental/coroutine> for clang-cl and VC++ ";
 #endif
 #define _EXPERIMENTAL_RESUMABLE_
 
-#else // use default header and use them if possible
+#elif defined(USE_CUSTOM_HEADER) // use custom header(this file)
+//
+// case: clang-cl, VC++
+// case: msvc, VC++
+// case: clang, libc++
+//
+#else                            // use default header
 //
 // case: msvc, VC++
 // case: clang, libc++
 //	It is safe to use vendor's header.
 //	by defining macro variable, user can prevent template redefinition
 //
-#if __has_include(<coroutine>) 
+#if __has_include(<coroutine>)
 #include <coroutine> // C++ 20 standard
 //#define COROUTINE_FRAME_PREFIX_HPP // todo: check if the header works well
 
-#elif __has_include(<experimental/coroutine>) 
+#elif __has_include(<experimental/coroutine>)
 #include <experimental/coroutine>  // C++ 17 experimetal
 #define COROUTINE_FRAME_PREFIX_HPP // yield to VC++/libc++
 
 #endif // use default header
 #endif // <coroutine> header
-
 
 #ifndef COROUTINE_FRAME_PREFIX_HPP
 #define COROUTINE_FRAME_PREFIX_HPP

--- a/interface/coroutine/return.h
+++ b/interface/coroutine/return.h
@@ -54,7 +54,6 @@ class no_return final {
 class frame final : public coroutine_handle<void>, public suspend_always {
   public:
     struct promise_type final {
-        // No suspend for init/final suspension point
         auto initial_suspend() noexcept {
             return suspend_never{};
         }

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -34,6 +34,14 @@ PRIVATE
                         # end user will manage the path properly
 )
 
+if(USE_CUSTOM_HEADER)
+    message(STATUS "using custom coroutine header")
+    target_compile_definitions(${PROJECT_NAME}
+    PUBLIC
+        USE_CUSTOM_HEADER
+    )
+endif()
+
 # library export / install
 include(CMakePackageConfigHelpers)
 set(VERSION_FILE        ${CMAKE_BINARY_DIR}/cmake/coroutine-config-version.cmake)

--- a/modules/darwin.cmake
+++ b/modules/darwin.cmake
@@ -10,7 +10,11 @@ endif()
 
 add_library(${PROJECT_NAME}
     darwin/dllmain.cpp
+    darwin/kernel_queue.cpp
+    darwin/kernel_queue.h
+    darwin/event.cpp
     darwin/net.cpp
+
     posix/concrt.cpp
     net/resolver.cpp
 )

--- a/modules/darwin/event.cpp
+++ b/modules/darwin/event.cpp
@@ -1,0 +1,148 @@
+// ---------------------------------------------------------------------------
+//
+//  Author  : github.com/luncliff (luncliff@gmail.com)
+//  License : CC BY 4.0
+//
+// ---------------------------------------------------------------------------
+#include <coroutine/concrt.h>
+#include <coroutine/net.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <system_error>
+
+#include <sys/un.h>
+
+#include "./kernel_queue.h"
+
+namespace concrt {
+using namespace std;
+
+// see also: `linux/event.cpp`
+kernel_queue_t selist{};
+
+// mock eventfd using pimpl idiom.
+// instead of `eventfd` in linux, we are going to use 'unix domain socket'
+// possible alternative is `fifo`, but it also requires path management.
+struct unix_event_t final : no_copy_move {
+    int64_t sd;
+    int64_t msg;
+    sockaddr_un local;
+
+  public:
+    unix_event_t() noexcept(false) : sd{}, msg{}, local{} {
+        // use short path
+        constexpr auto example = "/tmp/coro_ev_XXXXXX";
+        strncpy(local.sun_path, example, strnlen(example, 20));
+
+        // ensure path exists using 'mkstemp'
+        sd = mkstemp(local.sun_path);
+        if (sd == -1)
+            throw system_error{errno, system_category(), "mkstemp"};
+        if (close(sd))
+            throw system_error{errno, system_category(), "close"};
+        if (remove(local.sun_path))
+            throw system_error{errno, system_category(), "remove"};
+
+        // prepare unix domain socket
+        sd = socket(AF_UNIX, SOCK_DGRAM, 0);
+        if (sd == -1)
+            throw system_error{errno, system_category(), "socket"};
+
+        // local.sun_path is already set.
+        local.sun_family = AF_UNIX;
+
+        if (::bind(sd, (sockaddr*)&local, SUN_LEN(&local)))
+            throw system_error{errno, system_category(), "bind"};
+    }
+    ~unix_event_t() noexcept {
+        close(sd);
+        unlink(local.sun_path); // don't forget this!
+    }
+
+    void signal() noexcept(false) {
+        socklen_t len = SUN_LEN(&local);
+        // send 8 byte (size of state) to buffer
+        auto sz = sendto(sd, &msg, sizeof(msg), 0, (sockaddr*)&local, len);
+        if (sz == -1)
+            throw system_error{errno, system_category(), "sendto"};
+
+        msg = 1; // signaled
+    }
+    bool is_signaled() noexcept {
+        return msg != 0;
+    }
+    void consume() noexcept(false) {
+        // socket buffer is limited. we must consume properly
+        auto sz = recvfrom(sd, &msg, sizeof(msg), 0, nullptr, nullptr);
+        if (sz == -1)
+            throw system_error{errno, system_category(), "recvfrom"};
+
+        // by receiving message, it recovers non-signaled state
+        // we are using assert since this is critical
+        assert(msg == 0);
+    }
+};
+
+event::event() noexcept(false) : state{} {
+    auto* impl = new (std::nothrow) unix_event_t{};
+    if (impl == nullptr)
+        throw runtime_error{"failed to allocate data for event"};
+
+    state = reinterpret_cast<uint64_t>(impl);
+}
+event::~event() noexcept {
+    auto* impl = reinterpret_cast<unix_event_t*>(state);
+    delete impl;
+}
+
+bool event::is_ready() const noexcept {
+    auto* impl = reinterpret_cast<unix_event_t*>(state);
+    return impl->is_signaled();
+}
+
+void event::set() noexcept(false) {
+    auto* impl = reinterpret_cast<unix_event_t*>(state);
+    if (impl->is_signaled())
+        // !!! under the race condition, this check is not safe !!!
+        return;
+
+    impl->signal();
+}
+
+void event::on_suspend(task t) noexcept(false) {
+    auto* impl = reinterpret_cast<unix_event_t*>(state);
+
+    kevent64_s req{};
+    req.ident = impl->sd;
+    req.filter = EVFILT_READ;
+    req.flags = EV_ADD | EV_ENABLE | EV_ONESHOT;
+    req.fflags = 0;
+    req.data = 0;
+    req.udata = reinterpret_cast<uint64_t>(t.address());
+
+    selist.change(req);
+}
+void event::on_resume() noexcept {
+    auto* impl = reinterpret_cast<unix_event_t*>(state);
+    impl->consume();
+}
+
+auto signaled_event_tasks() noexcept(false) -> coro::enumerable<event::task> {
+    event::task t{};
+    timespec ts{}; // zero wait
+
+    // notice that the timeout is zero
+    for (auto ev : selist.wait(ts)) {
+
+        t = event::task::from_address(reinterpret_cast<void*>(ev.udata));
+        // todo: check only for debug mode?
+        if (t.done())
+            throw invalid_argument{"event::task is already done state"};
+
+        co_yield t;
+    }
+    co_return;
+}
+
+} // namespace concrt

--- a/modules/darwin/kernel_queue.cpp
+++ b/modules/darwin/kernel_queue.cpp
@@ -1,0 +1,95 @@
+// ---------------------------------------------------------------------------
+//
+//  Author  : github.com/luncliff (luncliff@gmail.com)
+//  License : CC BY 4.0
+//
+// ---------------------------------------------------------------------------
+#include "./kernel_queue.h"
+
+#include <system_error>
+using namespace std;
+
+kernel_queue_t::kernel_queue_t() noexcept(false)
+    : kqfd{-1},
+      // use 2 page for polling
+      capacity{2 * getpagesize() / sizeof(kevent64_s)},
+      events{make_unique<kevent64_s[]>(capacity)} {
+    kqfd = kqueue();
+    if (kqfd < 0)
+        throw system_error{errno, system_category(), "kqueue"};
+}
+kernel_queue_t::~kernel_queue_t() noexcept {
+    close(kqfd);
+}
+void kernel_queue_t::change(kevent64_s& req) noexcept(false) {
+    // attach the event config
+    auto ec = kevent64(kqfd, &req, 1, nullptr, 0, 0, nullptr);
+    if (ec == -1)
+        throw system_error{errno, system_category(), "kevent64"};
+}
+auto kernel_queue_t::wait(const timespec& ts) noexcept(false)
+    -> coro::enumerable<kevent64_s> {
+    // wait for events ...
+    auto count = kevent64(kqfd, nullptr, 0,       //
+                          events.get(), capacity, //
+                          0, &ts);
+    if (count == -1)
+        throw system_error{errno, system_category(), "kevent64"};
+
+    for (auto i = 0; i < count; ++i) {
+        co_yield events[i];
+    }
+}
+
+void print_kevent(const kevent64_s& ev) {
+    printf(" ev.ident \t: %llu\n", ev.ident);
+
+    if (ev.filter == EVFILT_READ)
+        printf(" ev.filter\t: EVFILT_READ\n");
+    if (ev.filter == EVFILT_WRITE)
+        printf(" ev.filter\t: EVFILT_WRITE\n");
+    if (ev.filter == EVFILT_EXCEPT)
+        printf(" ev.filter\t: EVFILT_EXCEPT\n");
+    if (ev.filter == EVFILT_AIO)
+        printf(" ev.filter\t: EVFILT_AIO\n");
+    if (ev.filter == EVFILT_VNODE)
+        printf(" ev.filter\t: EVFILT_VNODE\n");
+    if (ev.filter == EVFILT_PROC)
+        printf(" ev.filter\t: EVFILT_PROC\n");
+    if (ev.filter == EVFILT_SIGNAL)
+        printf(" ev.filter\t: EVFILT_SIGNAL\n");
+    if (ev.filter == EVFILT_MACHPORT)
+        printf(" ev.filter\t: EVFILT_MACHPORT\n");
+    if (ev.filter == EVFILT_TIMER)
+        printf(" ev.filter\t: EVFILT_TIMER\n");
+
+    if (ev.flags & EV_ADD)
+        printf(" ev.flags\t: EV_ADD\n");
+    if (ev.flags & EV_DELETE)
+        printf(" ev.flags\t: EV_DELETE\n");
+    if (ev.flags & EV_ENABLE)
+        printf(" ev.flags\t: EV_ENABLE\n");
+    if (ev.flags & EV_DISABLE)
+        printf(" ev.flags\t: EV_DISABLE\n");
+    if (ev.flags & EV_ONESHOT)
+        printf(" ev.flags\t: EV_ONESHOT\n");
+    if (ev.flags & EV_CLEAR)
+        printf(" ev.flags\t: EV_CLEAR\n");
+    if (ev.flags & EV_RECEIPT)
+        printf(" ev.flags\t: EV_RECEIPT\n");
+    if (ev.flags & EV_DISPATCH)
+        printf(" ev.flags\t: EV_DISPATCH\n");
+    if (ev.flags & EV_UDATA_SPECIFIC)
+        printf(" ev.flags\t: EV_UDATA_SPECIFIC\n");
+    if (ev.flags & EV_VANISHED)
+        printf(" ev.flags\t: EV_VANISHED\n");
+    if (ev.flags & EV_ERROR)
+        printf(" ev.flags\t: EV_ERROR\n");
+    if (ev.flags & EV_OOBAND)
+        printf(" ev.flags\t: EV_OOBAND\n");
+    if (ev.flags & EV_EOF)
+        printf(" ev.flags\t: EV_EOF\n");
+
+    printf(" ev.data\t: %lld\n", ev.data);
+    printf(" ev.udata\t: %llx, %llu\n", ev.udata, ev.udata);
+}

--- a/modules/darwin/kernel_queue.h
+++ b/modules/darwin/kernel_queue.h
@@ -1,0 +1,33 @@
+// ---------------------------------------------------------------------------
+//
+//  Author  : github.com/luncliff (luncliff@gmail.com)
+//  License : CC BY 4.0
+//
+// ---------------------------------------------------------------------------
+#pragma once
+#ifndef DARWIN_KERNEL_QUEUE_API_WRAPPER_H
+#define DARWIN_KERNEL_QUEUE_API_WRAPPER_H
+
+#include <coroutine/yield.hpp>
+
+#include <memory>
+
+#include <fcntl.h>
+#include <sys/event.h>
+#include <unistd.h>
+
+struct kernel_queue_t final {
+    int kqfd;
+    const size_t capacity;
+    std::unique_ptr<kevent64_s[]> events;
+
+  public:
+    kernel_queue_t() noexcept(false);
+    ~kernel_queue_t() noexcept;
+
+    void change(kevent64_s& req) noexcept(false);
+    auto wait(const timespec& ts) noexcept(false)
+        -> coro::enumerable<kevent64_s>;
+};
+
+#endif // DARWIN_KERNEL_QUEUE_API_WRAPPER_H

--- a/modules/linux.cmake
+++ b/modules/linux.cmake
@@ -10,12 +10,13 @@ endif()
 
 add_library(${PROJECT_NAME}
     linux/dllmain.cpp
+
     linux/event_poll.h
     linux/event_poll.cpp
-    linux/net.cpp
-    linux/concrt.cpp
-
+    linux/event.cpp
+    
     posix/concrt.cpp
+    linux/net.cpp
     net/resolver.cpp
 )
 

--- a/modules/linux.cmake
+++ b/modules/linux.cmake
@@ -10,7 +10,11 @@ endif()
 
 add_library(${PROJECT_NAME}
     linux/dllmain.cpp
+    linux/event_poll.h
+    linux/event_poll.cpp
     linux/net.cpp
+    linux/concrt.cpp
+
     posix/concrt.cpp
     net/resolver.cpp
 )

--- a/modules/linux/concrt.cpp
+++ b/modules/linux/concrt.cpp
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------------
+//
+//  Author  : github.com/luncliff (luncliff@gmail.com)
+//  License : CC BY 4.0
+//
+// ---------------------------------------------------------------------------
+#include <coroutine/concrt.h>
+
+#include <sys/eventfd.h>
+
+#include "./event_poll.h"
+
+namespace concrt {
+
+event_poll_t events{};
+
+event::event() noexcept(false) : id{} {
+    const auto fd = eventfd(0, EFD_CLOEXEC);
+    if (fd == -1)
+        throw system_error{errno, system_category(), "eventfd"};
+
+    id = static_cast<decltype(id)>(fd);
+}
+event::~event() noexcept {
+    close(id);
+}
+
+void event::on_suspend(task t) noexcept(false) {
+    internal = t.address();
+    // report when read is available
+    epoll_event req{};
+    req.events = EPOLLIN;
+    req.data.fd = id;
+
+    // throws if epoll_ctl fails
+    events.try_add(id, req);
+}
+
+void event::set() noexcept(false) {
+    const auto sz = write(id, &internal, sizeof(internal));
+    if (sz == -1)
+        throw system_error{errno, system_category(), "write"};
+}
+
+auto signaled_event_tasks() noexcept(false) -> coro::enumerable<event::task> {
+    event::task task{};
+
+    // fetch immediately
+    for (auto e : events.wait(0)) {
+        const auto sz = read(e.data.fd, &task, sizeof(task));
+        if (sz == -1)
+            throw system_error{errno, system_category(), "read"};
+
+        puts("signaled_event_tasks");
+
+        co_yield task;
+    }
+    co_return;
+}
+
+} // namespace concrt

--- a/modules/linux/event.cpp
+++ b/modules/linux/event.cpp
@@ -87,7 +87,7 @@ void event::on_suspend(task t) noexcept(false) {
     // just care if there was `write` for the eventfd
     //  when it happens, coroutine handle will be forwarded by epoll
     epoll_event req{};
-    req.events = EPOLLET | EPOLLIN | EPOLLEXCLUSIVE | EPOLLONESHOT;
+    req.events = EPOLLET | EPOLLIN | EPOLLONESHOT;
     req.data.ptr = t.address();
 
     // throws if `epoll_ctl` fails

--- a/modules/linux/event.cpp
+++ b/modules/linux/event.cpp
@@ -12,62 +12,102 @@
 
 namespace concrt {
 
-event_poll_t events{};
+// signaled event list. it's badly named to prevent possible collision
+event_poll_t selist{};
 
-event::event() noexcept(false) : id{}, coro{} {
+//
+//  We are going to combine file descriptor and state bit
+//
+//  On x86 system,
+//    this won't matter since `int` is 32 bit.
+//    we can safely use msb for state indicator.
+//
+//  On x64 system,
+//    this might be a hazardous since the value of `eventfd` can be corrupted.
+//    **Normally** descriptor in Linux system grows from 3, so it is highly
+//    possible to reach system limitation before the value consumes all 63 bit.
+//
+constexpr uint64_t emask = 1ULL << 63;
+
+//  the msb(most significant bit) will be ...
+//   1 if the fd is signaled,
+//   0 on the other case
+bool is_signaled(uint64_t state) noexcept {
+    return emask & state; // msb is 1?
+}
+int64_t get_eventfd(uint64_t state) noexcept {
+    return static_cast<int64_t>(~emask & state);
+}
+uint64_t make_signaled(int64_t efd) noexcept(false) {
+    // signal the eventfd...
+    //  the message can be any value
+    //  since the purpose of it is to trigger the epoll
+    //  we won't care about the internal counter of the eventfd
+    auto sz = write(efd, &efd, sizeof(efd));
+    if (sz == -1)
+        throw system_error{errno, system_category(), "write"};
+
+    return emask | static_cast<uint64_t>(efd);
+}
+
+event::event() noexcept(false) : state{} {
     const auto fd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
     if (fd == -1)
         throw system_error{errno, system_category(), "eventfd"};
 
-    id = static_cast<decltype(id)>(fd);
+    this->state = fd; // start with unsignaled state
 }
 event::~event() noexcept {
-    if (id)
-        close(id);
-}
-bool event::is_ready() noexcept {
-    return id == 0; // already siganled
+    // if already closed, fd == 0
+    if (auto fd = get_eventfd(state))
+        close(fd);
 }
 
+void event::set() noexcept(false) {
+    // already signaled. nothing to do...
+    if (is_signaled(state))
+        // !!! under the race condition, this check is not safe !!!
+        return;
+
+    auto fd = get_eventfd(state);
+    state = make_signaled(fd); // if it didn't throwed
+                               //  it's signaled state from now
+}
+bool event::is_ready() const noexcept {
+    return is_signaled(state);
+}
 void event::on_resume() noexcept {
-    // nothing to do here ...
+    // make unsignaled state
+    this->state = static_cast<decltype(state)>(get_eventfd(state));
 }
 
 // Reference
 //  https://github.com/grpc/grpc/blob/master/src/core/lib/iomgr/is_epollexclusive_available.cc
 void event::on_suspend(task t) noexcept(false) {
-    this->coro = t;
-    // printf("%p \n", coro.address());
-    // report when read is available
+    // just care if there was `write` for the eventfd
+    //  when it happens, coroutine handle will be forwarded by epoll
     epoll_event req{};
     req.events = EPOLLET | EPOLLIN | EPOLLEXCLUSIVE | EPOLLONESHOT;
-    req.data.fd = id;
+    req.data.ptr = t.address();
 
-    // throws if epoll_ctl fails
-    events.try_add(id, req);
-}
-
-void event::set() noexcept(false) {
-    // it is not suspended
-    if (static_cast<bool>(coro) == false) {
-        close(id);
-        id = 0;
-        return;
-    }
-    // suspended. signal the eventfd
-    auto sz = write(id, &coro, sizeof(coro));
-    if (sz == -1)
-        throw system_error{errno, system_category(), "write"};
+    // throws if `epoll_ctl` fails
+    selist.try_add(get_eventfd(state), req);
 }
 
 auto signaled_event_tasks() noexcept(false) -> coro::enumerable<event::task> {
     event::task t{};
 
-    // fetch immediately
-    for (auto e : events.wait(0)) {
-        auto sz = read(e.data.fd, &t, sizeof(t));
-        if (sz == -1)
-            throw system_error{errno, system_category(), "read"};
+    // notice that the timeout is zero
+    for (auto e : selist.wait(0)) {
+        // see also: `make_signaled`, `event::on_suspend`
+        // we don't care about the internal counter.
+        //  just receive the coroutine handle
+        t = event::task::from_address(e.data.ptr);
+
+        // ensure we can resume it.
+        // todo: check only for debug mode?
+        if (t.done())
+            throw invalid_argument{"event::task is already done state"};
 
         co_yield t;
     }

--- a/modules/linux/event_poll.cpp
+++ b/modules/linux/event_poll.cpp
@@ -1,0 +1,55 @@
+// ---------------------------------------------------------------------------
+//
+//  Author  : github.com/luncliff (luncliff@gmail.com)
+//  License : CC BY 4.0
+//
+// ---------------------------------------------------------------------------
+#include "./event_poll.h"
+
+#include <system_error>
+using namespace std;
+
+event_poll_t::event_poll_t() noexcept(false)
+    : fd{-1},
+      // use 2 page for polling
+      capacity{2 * getpagesize() / sizeof(epoll_event)},
+      events{make_unique<epoll_event[]>(capacity)} {
+    fd = epoll_create1(EPOLL_CLOEXEC);
+    if (fd < 0)
+        throw system_error{errno, system_category(), "epoll_create1"};
+}
+event_poll_t::~event_poll_t() noexcept {
+    close(fd);
+}
+
+void event_poll_t::try_add(uint64_t fd, epoll_event& req) noexcept(false) {
+    int op = EPOLL_CTL_ADD, ec = 0;
+TRY_OP:
+    ec = epoll_ctl(fd, op, fd, &req);
+    if (ec == 0)
+        return;
+    if (errno == EEXIST) {
+        op = EPOLL_CTL_MOD; // already exists. try with modification
+        goto TRY_OP;
+    }
+
+    throw system_error{errno, system_category(), "epoll_ctl"};
+}
+
+void event_poll_t::remove(uint64_t fd) {
+    epoll_event req{}; // just prevent non-null input
+    const auto ec = epoll_ctl(fd, EPOLL_CTL_DEL, fd, &req);
+    if (ec != 0)
+        throw system_error{errno, system_category(), "epoll_ctl"};
+}
+
+auto event_poll_t::wait(int timeout) noexcept(false)
+    -> coro::enumerable<epoll_event> {
+    auto count = epoll_wait(fd, events.get(), capacity, timeout);
+    if (count == -1)
+        throw system_error{errno, system_category(), "epoll_wait"};
+
+    for (auto i = 0; i < count; ++i) {
+        co_yield events[i];
+    }
+}

--- a/modules/linux/event_poll.h
+++ b/modules/linux/event_poll.h
@@ -1,0 +1,33 @@
+// ---------------------------------------------------------------------------
+//
+//  Author  : github.com/luncliff (luncliff@gmail.com)
+//  License : CC BY 4.0
+//
+// ---------------------------------------------------------------------------
+#pragma once
+#ifndef LINUX_EVENT_POLL_API_WRAPPER_H
+#define LINUX_EVENT_POLL_API_WRAPPER_H
+
+#include <coroutine/yield.hpp>
+
+#include <memory>
+
+#include <fcntl.h>
+#include <sys/epoll.h>
+#include <unistd.h>
+
+struct event_poll_t final {
+    int fd;
+    const size_t capacity;
+    std::unique_ptr<epoll_event[]> events;
+
+  public:
+    event_poll_t() noexcept(false);
+    ~event_poll_t() noexcept;
+
+    void try_add(uint64_t fd, epoll_event& req) noexcept(false);
+    void remove(uint64_t fd);
+    auto wait(int timeout) noexcept(false) -> coro::enumerable<epoll_event>;
+};
+
+#endif // LINUX_EVENT_POLL_API_WRAPPER_H

--- a/modules/linux/event_poll.h
+++ b/modules/linux/event_poll.h
@@ -17,7 +17,7 @@
 #include <unistd.h>
 
 struct event_poll_t final {
-    int fd;
+    int epfd;
     const size_t capacity;
     std::unique_ptr<epoll_event[]> events;
 

--- a/modules/windows.cmake
+++ b/modules/windows.cmake
@@ -11,7 +11,7 @@ add_library(${PROJECT_NAME}
 )
 target_compile_definitions(${PROJECT_NAME}
 PRIVATE
-    WIN32_MEAN_AND_LEAN
+    WIN32_LEAN_AND_MEAN
 PUBLIC
     NOMINMAX
 )

--- a/modules/windows.cmake
+++ b/modules/windows.cmake
@@ -10,6 +10,8 @@ add_library(${PROJECT_NAME}
     net/resolver.cpp
 )
 target_compile_definitions(${PROJECT_NAME}
+PRIVATE
+    WIN32_MEAN_AND_LEAN
 PUBLIC
     NOMINMAX
 )

--- a/modules/windows.vcxproj
+++ b/modules/windows.vcxproj
@@ -122,7 +122,7 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NOMINMAX;WIN32;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;WIN32;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(SolutionDir)interface;$(ProjectDir);$(SolutionDir)external\guideline\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -157,7 +157,7 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NOMINMAX;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(SolutionDir)interface;$(ProjectDir);$(SolutionDir)external\guideline\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -194,7 +194,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NOMINMAX;WIN32;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;WIN32;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(SolutionDir)interface;$(ProjectDir);$(SolutionDir)external\guideline\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -232,7 +232,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NOMINMAX;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(SolutionDir)interface;$(ProjectDir);$(SolutionDir)external\guideline\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,6 @@ add_executable(coroutine_test
     c2_entry.cpp
     c2_return.cpp
     c2_concrt.cpp
-    c2_concrt_event.cpp
     c2_channel.cpp
     c2_yield.cpp
 
@@ -19,6 +18,12 @@ add_executable(coroutine_test
     c2_socket_echo_udp.cpp
     c2_socket_echo_tcp.cpp
 )
+if(UNIX AND NOT APPLE)
+    target_sources(coroutine_test
+    PRIVATE
+        c2_concrt_event.cpp
+    )
+endif()
 
 set_target_properties(coroutine_test
 PROPERTIES

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(coroutine_test
     c2_entry.cpp
     c2_return.cpp
     c2_concrt.cpp
+    c2_concrt_event.cpp
     c2_channel.cpp
     c2_yield.cpp
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,7 @@ add_executable(coroutine_test
     c2_socket_echo_udp.cpp
     c2_socket_echo_tcp.cpp
 )
-if(UNIX AND NOT APPLE)
+if(UNIX)
     target_sources(coroutine_test
     PRIVATE
         c2_concrt_event.cpp

--- a/test/c2_concrt.cpp
+++ b/test/c2_concrt.cpp
@@ -2,17 +2,16 @@
 //  Author  : github.com/luncliff (luncliff@gmail.com)
 //  License : CC BY 4.0
 //
-#include <coroutine/concrt.h>
-
 #include <catch2/catch.hpp>
+
+#include <coroutine/concrt.h>
+using namespace coro;
 
 #include <array>
 #include <future>
 #include <queue>
-
 using namespace std;
-using namespace literals;
-using namespace std::experimental;
+using namespace std::literals;
 
 TEST_CASE("latch", "[concurrency][thread]") {
     using wait_group = concrt::latch; // the type's name in Go Language
@@ -58,8 +57,6 @@ TEST_CASE("latch", "[concurrency][thread]") {
         }
     }
 }
-
-using namespace coro;
 
 TEST_CASE("frame holder is coroutine_handle", "[return]") {
     frame fh{};

--- a/test/c2_concrt_event.cpp
+++ b/test/c2_concrt_event.cpp
@@ -32,13 +32,14 @@ TEST_CASE("wait for one event", "[event]") {
     wait_for_one_event(e1, flag);
 
     e1.set();
-    auto count = 0;
+    // auto count = 0;
+
     for (auto task : signaled_event_tasks()) {
-        REQUIRE(task.done() == false);
         task.resume();
-        ++count;
+        // ++count;
     }
-    REQUIRE(count > 0);
+
+    // REQUIRE(count > 0);
     // already set by the coroutine `wait_for_one_event`
     REQUIRE(flag.test_and_set() == true);
 }
@@ -55,12 +56,17 @@ TEST_CASE("wait for event multiple times", "[event]") {
     counter = 6;
     wait_for_multiple_times(e1, counter);
 
-    while (counter > 0) {
-        e1.set();
+    auto repeat = 100u; // prevent infinite loop
+    REQUIRE(repeat > counter);
+    REQUIRE(counter > 0);
 
+    while (counter > 0 && repeat > 0) {
+        e1.set();
         // resume if there is available event-waiting coroutines
         for (auto task : signaled_event_tasks())
             task.resume();
+
+        --repeat;
     };
     REQUIRE(counter == 0);
 }

--- a/test/c2_concrt_event.cpp
+++ b/test/c2_concrt_event.cpp
@@ -1,0 +1,73 @@
+//
+//  Author  : github.com/luncliff (luncliff@gmail.com)
+//  License : CC BY 4.0
+//
+#include <catch2/catch.hpp>
+
+#include <coroutine/concrt.h>
+using namespace coro;
+using namespace concrt;
+
+#include <array>
+#include <atomic>
+using namespace std;
+
+auto wait_for_one_event(event& e, atomic_flag& flag) -> no_return {
+    try {
+        // resume after the event is signaled ...
+        co_await e;
+
+    } catch (system_error& e) {
+        FAIL(e.what());
+    }
+    flag.test_and_set();
+}
+
+TEST_CASE("wait for one event", "[event]") {
+    event e1{};
+    atomic_flag flag = ATOMIC_FLAG_INIT;
+
+    wait_for_one_event(e1, flag);
+
+    e1.set();
+    auto count = 0;
+    for (auto task : signaled_event_tasks()) {
+        REQUIRE(task.done() == false);
+        task.resume();
+        ++count;
+    }
+    REQUIRE(count > 0);
+    // already set by the coroutine `wait_for_one_event`
+    REQUIRE(flag.test_and_set() == true);
+}
+
+auto wait_three_events(event& e1, event& e2, event& e3, atomic_flag& flag)
+    -> no_return {
+
+    co_await e1;
+    co_await e2;
+    co_await e3;
+
+    flag.test_and_set();
+}
+
+TEST_CASE("wait for multiple events", "[event]") {
+    array<event, 3> events{};
+    atomic_flag flag = ATOMIC_FLAG_INIT;
+
+    wait_three_events(events[0], events[1], events[2], flag);
+
+    // signal in descending order. notice the order in the test function ...
+    for (auto idx : {2, 1, 0}) {
+        events[idx].set();
+
+        auto count = 0;
+        for (auto task : signaled_event_tasks()) {
+            task.resume();
+            ++count;
+        }
+        REQUIRE(count > 0);
+    }
+    // set by the coroutine `wait_three_events`
+    REQUIRE(flag.test_and_set() == true);
+}

--- a/test/vs_concrt.cpp
+++ b/test/vs_concrt.cpp
@@ -2,73 +2,71 @@
 //  Author  : github.com/luncliff (luncliff@gmail.com)
 //  License : CC BY 4.0
 //
-#include <coroutine/concrt.h>
-
 #include <CppUnitTest.h>
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
-using namespace std;
-using namespace std::literals;
-
-using namespace std::experimental;
+#include <coroutine/concrt.h>
 using namespace coro;
 using namespace concrt;
 
-class latch_test : public TestClass<latch_test>
-{
-    using wait_group = concrt::latch;
+#include <array>
 
-    static auto spawn_background_work(wait_group& group) -> no_return
-    {
-        co_await ptp_work{}; // move to background thread ...
-        group.count_down();
+class thread_api_test : public TestClass<thread_api_test> {
+
+    TEST_METHOD(thread_of_current_process) {
+        auto pid = GetCurrentProcessId();
+        bool detected = false;
+        // it's simple. find peer threads
+        for (auto tid : get_threads(pid)) {
+            if (tid == GetCurrentThreadId())
+                continue;
+            detected = true;
+        }
+        // since visual studio native test runs with multi-thread,
+        // there must be a peer thread for this test process
+        Assert::IsTrue(detected);
+    }
+};
+
+class latch_test : public TestClass<latch_test> {
+
+    static auto spawn_background_work(latch& wg) -> no_return {
+        co_await ptp_work{};
+        wg.count_down();
     }
 
-    TEST_METHOD(latch_ready_after_wait)
-    {
+    TEST_METHOD(latch_ready_after_wait) {
         constexpr auto num_of_work = 10u;
-        wait_group group{num_of_work};
+        latch wg{num_of_work};
 
         // fork - join
         for (auto i = 0u; i < num_of_work; ++i)
-            spawn_background_work(group);
+            spawn_background_work(wg);
 
-        group.wait();
-        Assert::IsTrue(group.is_ready());
+        wg.wait();
+        Assert::IsTrue(wg.is_ready());
     }
+    TEST_METHOD(latch_count_down_and_wait) {
+        latch wg{1};
+        Assert::IsTrue(wg.is_ready() == false);
 
-    TEST_METHOD(latch_count_down_and_wait)
-    {
-        wait_group group{1};
-        Assert::IsTrue(group.is_ready() == false);
-
-        group.count_down_and_wait();
-        Assert::IsTrue(group.is_ready());
+        wg.count_down_and_wait();
+        Assert::IsTrue(wg.is_ready());
     }
-
-    TEST_METHOD(latch_throws_for_negative_1)
-    {
-        wait_group group{1};
-        try
-        {
-            group.count_down(2);
-        }
-        catch (const underflow_error&)
-        {
+    TEST_METHOD(latch_throws_for_negative_1) {
+        latch wg{1};
+        try {
+            wg.count_down(2);
+        } catch (const underflow_error&) {
             return;
         }
         Assert::Fail();
     }
-
-    TEST_METHOD(latch_throws_for_negative_2)
-    {
-        wait_group group{0};
-        try
-        {
-            group.count_down_and_wait();
-        }
-        catch (const underflow_error&)
-        {
+    TEST_METHOD(latch_throws_for_negative_2) {
+        latch wg{0};
+        try {
+            wg.count_down_and_wait();
+        } catch (const underflow_error&) {
             return;
         }
         Assert::Fail();

--- a/test/vs_event.cpp
+++ b/test/vs_event.cpp
@@ -1,0 +1,112 @@
+//
+//  Author  : github.com/luncliff (luncliff@gmail.com)
+//  License : CC BY 4.0
+//
+#include <CppUnitTest.h>
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+#include <coroutine/concrt.h>
+using namespace coro;
+using namespace concrt;
+
+#include <array>
+
+class ptp_work_test : public TestClass<ptp_work_test> {
+
+    static auto set_after_sleep(HANDLE ev, uint32_t ms) -> no_return {
+        co_await ptp_work{}; // move to background thread ...
+
+        Sleep(ms);
+        // if failed, print error message
+        if (SetEvent(ev) == 0) {
+            auto ec = GetLastError();
+            auto m = system_category().message(ec);
+            Logger::WriteMessage(m.c_str());
+        }
+    }
+
+    array<HANDLE, 10> events{};
+
+    TEST_METHOD_INITIALIZE(create_events) {
+        for (auto& e : events) {
+            e = CreateEventEx(nullptr, nullptr, //
+                              CREATE_EVENT_MANUAL_RESET, EVENT_ALL_ACCESS);
+            Assert::IsTrue(e != NULL);
+            ResetEvent(e);
+        }
+    }
+    TEST_METHOD_CLEANUP(close_events) {
+        for (auto e : events)
+            CloseHandle(e);
+    }
+    TEST_METHOD(ptp_work_wait_one_event) {
+        HANDLE& e1 = events[0];
+        auto ms = rand() & 0b1111; // at most 16 ms
+
+        set_after_sleep(e1, ms);
+        // wait for 20 ms
+        auto ec = WaitForSingleObjectEx(e1, 20, true);
+        Assert::IsTrue(ec == WAIT_OBJECT_0);
+    }
+    TEST_METHOD(ptp_work_wait_multiple_event) {
+        for (auto e : events) {
+            auto ms = rand() & 0b1111; // at most 16 ms
+            set_after_sleep(e, ms);
+        }
+        // wait for 30 ms
+        auto ec = WaitForMultipleObjectsEx(events.max_size(), events.data(),
+                                           true, 30, true);
+        Assert::IsTrue(ec == WAIT_OBJECT_0);
+    }
+};
+
+class ptp_event_test : public TestClass<ptp_event_test> {
+
+    // we can't use rvalue reference. this design is necessary because
+    // `ptp_event` uses INFINITE wait internally.
+    // so, with the reference, user must sure one of `SetEvent` or `cancel` will
+    // happen in the future
+    static auto wait_an_event(ptp_event& token, atomic_flag& flag)
+        -> no_return {
+        // wait for set or cancel
+        // `co_await` will forward `GetLastError` if canceled.
+        if (DWORD ec = co_await token) {
+            auto emsg = system_category().message(ec);
+            Logger::WriteMessage(emsg.c_str());
+            return;
+        }
+        flag.test_and_set();
+    }
+
+    HANDLE ev;
+
+    TEST_METHOD_INITIALIZE(create_event) {
+        ev = CreateEventEx(nullptr, nullptr, //
+                           CREATE_EVENT_MANUAL_RESET, EVENT_ALL_ACCESS);
+        Assert::IsTrue(ev != NULL);
+        ResetEvent(ev);
+    }
+    TEST_METHOD_CLEANUP(close_event) {
+        CloseHandle(ev);
+    }
+    TEST_METHOD(ptp_event_set_event) {
+        ptp_event token{ev};
+        atomic_flag flag = ATOMIC_FLAG_INIT;
+
+        wait_an_event(token, flag);
+        SetEvent(ev);
+
+        Sleep(3); // wait for background thread
+        Assert::IsTrue(flag.test_and_set());
+    }
+    TEST_METHOD(ptp_event_cancel) {
+        ptp_event token{ev};
+        atomic_flag flag = ATOMIC_FLAG_INIT;
+
+        wait_an_event(token, flag);
+        token.cancel();
+
+        Sleep(3); // wait for background thread
+        Assert::IsFalse(flag.test_and_set());
+    }
+};

--- a/test/vs_event.cpp
+++ b/test/vs_event.cpp
@@ -44,8 +44,11 @@ class ptp_work_test : public TestClass<ptp_work_test> {
         auto ms = rand() & 0b1111; // at most 16 ms
 
         set_after_sleep(e1, ms);
-        // wait for 20 ms
-        auto ec = WaitForSingleObjectEx(e1, 20, true);
+
+        Sleep(3);
+        // issue: CI environment runs slowly, so too short timeout might fail
+        // wait for 200 ms
+        auto ec = WaitForSingleObjectEx(e1, 200, true);
         Assert::IsTrue(ec == WAIT_OBJECT_0);
     }
     TEST_METHOD(ptp_work_wait_multiple_event) {
@@ -53,9 +56,12 @@ class ptp_work_test : public TestClass<ptp_work_test> {
             auto ms = rand() & 0b1111; // at most 16 ms
             set_after_sleep(e, ms);
         }
-        // wait for 30 ms
+
+        Sleep(3);
+        // issue: CI environment runs slowly, so too short timeout might fail
+        // wait for 300 ms
         auto ec = WaitForMultipleObjectsEx(events.max_size(), events.data(),
-                                           true, 30, true);
+                                           true, 300, true);
         Assert::IsTrue(ec == WAIT_OBJECT_0);
     }
 };

--- a/test/vstest.vcxproj
+++ b/test/vstest.vcxproj
@@ -207,6 +207,7 @@
   <ItemGroup>
     <ClCompile Include="vs_channel.cpp" />
     <ClCompile Include="vs_concrt.cpp" />
+    <ClCompile Include="vs_event.cpp" />
     <ClCompile Include="vs_resolver.cpp" />
     <ClCompile Include="vs_return.cpp" />
     <ClCompile Include="vs_socket.cpp" />

--- a/test/vstest.vcxproj.filters
+++ b/test/vstest.vcxproj.filters
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="vs_concrt.cpp" />
     <ClCompile Include="vs_return.cpp" />
     <ClCompile Include="vs_yield.cpp" />
     <ClCompile Include="vs_channel.cpp" />
@@ -9,5 +8,7 @@
     <ClCompile Include="vs_socket.cpp" />
     <ClCompile Include="vs_socket_echo_tcp.cpp" />
     <ClCompile Include="vs_socket_echo_udp.cpp" />
+    <ClCompile Include="vs_concrt.cpp" />
+    <ClCompile Include="vs_event.cpp" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Note

The changes are about interface types in `<coroutine/concrt.h>`.

### Windows

* remove: `win32_event`
* new: `ptp_event`
   * event + waitable object

Implemented over Windows thread poll API. The type is for one-time usage.

```c++
//  Awaitable event with thread pool. Only for one-time usage
class ptp_event final : no_copy_move {
    HANDLE wo{};

  private:
    // WAITORTIMERCALLBACK
    static void __stdcall wait_on_thread_pool(PVOID, BOOLEAN);

    bool is_ready() const noexcept;
    void on_suspend(coroutine_handle<void>) noexcept(false);
    auto on_resume() noexcept -> uint32_t; // error code
  public:
    explicit ptp_event(HANDLE target) noexcept(false);
    ~ptp_event() noexcept;

    void cancel() noexcept;

    bool await_ready() noexcept {
        return this->is_ready();
    }
    void await_suspend(coroutine_handle<void> coro) noexcept(false) {
        return this->on_suspend(coro);
    }
    auto await_resume() noexcept {
        return this->on_resume();
    }
};
```

### Linux

* new: `event`
   * epoll + eventfd
* new: `signaled_event_tasks`

Even though the name is **too common**, `namespace concrt` will reduce to possibility of name collision.

```c++
// namespace concrt

class event final : no_copy_move {
  public:
    using task = coroutine_handle<void>;

  private:
    uint64_t state;

  private:
    void on_suspend(task) noexcept(false);
    bool is_ready() const noexcept;
    void on_resume() noexcept;

  public:
    event() noexcept(false);
    ~event() noexcept;

    void set() noexcept(false);

    bool await_ready() const noexcept {
        return this->is_ready();
    }
    void await_suspend(coroutine_handle<void> coro) noexcept(false) {
        return this->on_suspend(coro);
    }
    void await_resume() noexcept {
        return this->on_resume();
    }
};

//  Enumerate all suspended coroutines that are waiting for signaled events.
auto signaled_event_tasks() noexcept(false) -> coro::enumerable<event::task>;
```

### Mac OS (Darwin)

* new: `event`
   * kqueue + unix domain socket
* new: `signaled_event_tasks`

Its interface follows that of Linux. However, since FreeBSD doesn't have an `eventfd` feature, the internal implementation uses **unix domain socket**.

```c++
// mock eventfd using pimpl idiom.
// instead of `eventfd` in linux, we are going to use 'unix domain socket'
// possible alternative is `fifo`, but it also requires path management.
struct unix_event_t final : no_copy_move {
    int64_t sd;
    int64_t msg;
    sockaddr_un local;

  public:
    unix_event_t() noexcept(false);
    ~unix_event_t() noexcept ;

    void signal() noexcept(false) ;
    bool is_signaled() noexcept ;
    void reset() noexcept(false) ;
};
```

As mentioned in the comment above, the `state` member of `event`  is used as a pointer.

```c++
event::event() noexcept(false) : state{} {
    auto* impl = new (std::nothrow) unix_event_t{};
    if (impl == nullptr)
        throw runtime_error{"failed to allocate data for event"};

    state = reinterpret_cast<uint64_t>(impl);
}

event::~event() noexcept {
    auto* impl = reinterpret_cast<unix_event_t*>(state);
    delete impl;
}

bool event::is_ready() const noexcept {
    auto* impl = reinterpret_cast<unix_event_t*>(state);
    return impl->is_signaled();
}
```
