### PR TITLE
nullptr is implicit copyable to coroutine_handle?

### DIFF
--- a/interface/coroutine/frame.h
+++ b/interface/coroutine/frame.h
@@ -195,7 +195,7 @@ class coroutine_handle<void> {
     coroutine_handle& operator=(coroutine_handle const&) noexcept = default;
     coroutine_handle& operator=(coroutine_handle&& rhs) noexcept = default;
 
-    explicit coroutine_handle(std::nullptr_t) noexcept : prefix{nullptr} {
+    coroutine_handle(std::nullptr_t) noexcept : prefix{nullptr} {
     }
     coroutine_handle& operator=(nullptr_t) noexcept {
         prefix.v = nullptr;


### PR DESCRIPTION
I'm not sure what offcial in-progress papers state but I found that...

libc++ allows implicit :-
https://github.com/llvm-mirror/libcxx/blob/master/include/experimental/coroutine#L101

range-v3 uses implicit move constructor :-
https://github.com/ericniebler/range-v3/blob/master/include/range/v3/experimental/utility/generator.hpp#L324