### PR TITLE
add missing #include <cassert>

### DIFF
--- a/modules/event/event_windows.cpp
+++ b/modules/event/event_windows.cpp
@@ -14,6 +14,8 @@
 // Windows Concurrency Runtime's event is not alertible.
 //#include <concrt.h>
 
+#include <cassert>
+
 using namespace std;
 using namespace gsl;
 


### PR DESCRIPTION
Ran into this issue while updating the GSL on vcpkg. microsoft/vcpkg#9624

Note, the current version on vcpkg, 74467cb470a6bf8b9559a56ebdcb68ff915d871e (release 1.4.3), is also incompatible with current GSL versions.
The code resides there in a different file: [concrt.cpp](https://github.com/luncliff/coroutine/blob/74467cb470a6bf8b9559a56ebdcb68ff915d871e/modules/windows/concrt.cpp#L33)

When you merge this I'll submit the resulting HEAD to vcpkg, unless you suggest otherwise.