### PR TITLE
mark couroutine_handle::from_address as noexcept to satisfy clang13

### DIFF
--- a/interface/coroutine/frame.h
+++ b/interface/coroutine/frame.h
@@ -121,7 +121,7 @@ struct coroutine_handle : public coroutine_handle<void> {
         return *this;
     }
     // 17.12.3.2, export/import
-    static /*constexpr*/ coroutine_handle from_address(void* _Addr) {
+    static /*constexpr*/ coroutine_handle from_address(void* _Addr) noexcept {
         coroutine_handle _Result{};
         _Result._Ptr = reinterpret_cast<portable_coro_prefix*>(_Addr);
         return _Result;


### PR DESCRIPTION
Not really sure if this is supposed to be noexcept, but clang13 fails to
build anything due to this error.